### PR TITLE
Rotate functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+nordvpn_token.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  vpn:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: vpn
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    secrets:
+      - nordvpn_token
+    environment:
+      - TECHNOLOGY=NordLynx
+      - TOKENFILE=/run/secrets/nordvpn_token
+    restart: unless-stopped
+
+secrets:
+  nordvpn_token:
+    file: ./nordvpn_token.txt

--- a/rootfs/etc/cron.d/rotate.cron
+++ b/rootfs/etc/cron.d/rotate.cron
@@ -1,0 +1,3 @@
+*/3 * * * * /bin/bash /root/rotate_ip.sh
+@reboot /bin/bash /root/rotate_ip.sh
+

--- a/rootfs/root/rotate_ip.sh
+++ b/rootfs/root/rotate_ip.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+countries=$(nordvpn countries | tr , "\n" | shuf -n 1)
+$(echo "$x" | awk '{print $1}')
+random_country=$(echo "$countries" | awk '{print $1}')
+# connect to that country
+echo "Connecting to $random_country..."
+nordvpn connect "$random_country"


### PR DESCRIPTION
This pull request introduces several updates to enhance the Docker-based NordVPN setup, including adding cron-based IP rotation, improving the Dockerfile, and defining a `docker-compose.yml` configuration for easier deployment. The most important changes are grouped below:

### Dockerfile Enhancements:
* Added installation of `cron`, `vim`, and `gawk` to the Docker image to support new features like cron jobs. (`Dockerfile`, [DockerfileR11](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R11))
* Updated the `CMD` to start the NordVPN service, execute VPN setup commands, and enable the cron service for IP rotation. (`Dockerfile`, [DockerfileL23-R31](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R31))
* Added a `RUN` command to set up a cron job from `/etc/cron.d/rotate.cron` and made scripts in `/usr/bin` executable. (`Dockerfile`, [DockerfileL23-R31](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R31))

### Docker Compose Configuration:
* Introduced a `docker-compose.yml` file to define a `vpn` service with build context, necessary capabilities (`NET_ADMIN`, `NET_RAW`), secrets for NordVPN token management, and environment variables for configuration. (`docker-compose.yml`, [docker-compose.ymlR1-R19](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R19))

### Cron Job for IP Rotation:
* Added a cron job in `/etc/cron.d/rotate.cron` to periodically rotate the VPN IP every 3 minutes and at system reboot. (`rootfs/etc/cron.d/rotate.cron`, [rootfs/etc/cron.d/rotate.cronR1-R3](diffhunk://#diff-600afd48f867ba1bc34ea3783927aff56ddd99cb0e81f7f2cdf75e4f3da358a1R1-R3))
* Implemented the `rotate_ip.sh` script to randomly select a country and connect to it using NordVPN, enabling dynamic IP rotation. (`rootfs/root/rotate_ip.sh`, [rootfs/root/rotate_ip.shR1-R8](diffhunk://#diff-66c1bdd1d5cfdc79f26dfcb2473df20e5bd06ac845a86f103ea7dbbf304f8ddeR1-R8))