### PR TITLE
Change rotate time

### DIFF
--- a/rootfs/etc/cron.d/rotate.cron
+++ b/rootfs/etc/cron.d/rotate.cron
@@ -1,3 +1,3 @@
-*/3 * * * * /bin/bash /root/rotate_ip.sh
+*/6 * * * * /bin/bash /root/rotate_ip.sh
 @reboot /bin/bash /root/rotate_ip.sh
 


### PR DESCRIPTION
This pull request includes a small change to the `rotate.cron` file, modifying the frequency of the `rotate_ip.sh` script execution from every 3 minutes to every 6 minutes. Additionally, a reboot directive for the script remains unchanged.